### PR TITLE
fix: 🛠️ resolve issue with temporary storage on Vercel for image uploads

### DIFF
--- a/src/app/api/photos/route.ts
+++ b/src/app/api/photos/route.ts
@@ -1,10 +1,15 @@
-import fs from 'fs'
 import { NextResponse } from 'next/server'
-import path from 'path'
 
 import { uploadImageToCloudinary } from '@/lib/cloudinary'
 import { THEMA } from '@/types'
 import { FormOutputData } from '@/types/api/photo'
+
+// Define the types for the form data
+interface FormInputData {
+	image: File
+	theme: THEMA
+	description: string
+}
 
 export async function POST(request: Request) {
 	try {
@@ -14,33 +19,34 @@ export async function POST(request: Request) {
 		const theme = formData.get('theme') as THEMA
 		const description = formData.get('description') as string
 
+		// Validate required fields
 		if (!image || !theme || !description) {
 			return NextResponse.json(
 				{ error: 'Missing required fields' },
 				{ status: 400 },
 			)
 		}
-		const tempDir = path.join(process.cwd(), 'temp')
-		const filePath = path.join(tempDir, image.name)
 
-		if (!fs.existsSync(tempDir)) {
-			fs.mkdirSync(tempDir)
+		// Upload the image to Cloudinary
+		const cloudinaryResult = await uploadImageToCloudinary(image)
+
+		// Validate the Cloudinary response
+		if (!cloudinaryResult || !cloudinaryResult.secure_url) {
+			return NextResponse.json(
+				{ error: 'Failed to upload image to Cloudinary' },
+				{ status: 500 },
+			)
 		}
 
-		const fileBuffer = await image.arrayBuffer()
-		fs.writeFileSync(filePath, Buffer.from(fileBuffer))
-
-		const cloudinaryResult: any = await uploadImageToCloudinary(filePath)
-		const imageUrl = cloudinaryResult.secure_url
-
-		const respose: FormOutputData = {
+		// Create the response object
+		const response: FormOutputData = {
 			imageId: cloudinaryResult.public_id,
-			url: imageUrl,
+			url: cloudinaryResult.secure_url,
 			theme: theme,
 			description: description,
 		}
 
-		return NextResponse.json(respose, { status: 200 })
+		return NextResponse.json(response, { status: 200 })
 	} catch (error: unknown) {
 		return NextResponse.json({ error: 'An error occurred' }, { status: 500 })
 	}

--- a/src/lib/cloudinary.ts
+++ b/src/lib/cloudinary.ts
@@ -1,5 +1,4 @@
 import { v2 as cloudinary } from 'cloudinary'
-import fs from 'fs'
 
 import { SocialMedia } from '@/types/api/photo'
 
@@ -10,16 +9,22 @@ cloudinary.config({
 	api_secret: process.env.CLOUDINARY_API_SECRET,
 })
 
-const uploadImageToCloudinary = async (image: string) => {
+const uploadImageToCloudinary = async (image: File) => {
 	try {
-		const uploadResponse = await cloudinary.uploader.upload(image, {
-			folder: 'hackathon',
-		})
+		// Convert the image to a buffer
+		const buffer = await image.arrayBuffer()
+		const base64Image = Buffer.from(buffer).toString('base64')
 
-		fs.unlinkSync(image)
+		// Upload the image to Cloudinary
+		const uploadResponse = await cloudinary.uploader.upload(
+			`data:image/png;base64,${base64Image}`,
+			{
+				folder: 'hackathon',
+			},
+		)
+
 		return uploadResponse
 	} catch (error) {
-		fs.unlinkSync(image)
 		throw new Error('Error uploading image to Cloudinary')
 	}
 }


### PR DESCRIPTION
- Removed the use of `fs` and `path` to avoid problems with ephemeral storage on Vercel.
- Changed image upload logic to convert the file to a buffer and upload directly to Cloudinary.
- Simplified the `uploadImageToCloudinary` function to handle file conversion and upload without storing the image locally.
- Maintained the expected response structure for consistency.